### PR TITLE
Added support for Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656755932,
+        "narHash": "sha256-TGThfOxr+HjFK464+UoUE6rClp2cwxjiKvHcBVdIGSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "660ac43ff9ab1f12e28bfb31d4719795777fe152",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "revanced-builder, A NodeJS ReVanced builder";
+
+  inputs = {
+    nixpkgs = { url = "github:NixOS/nixpkgs/nixpkgs-unstable"; };
+    flake-utils = { url = "github:numtide/flake-utils"; };
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        inherit (nixpkgs.lib) optional;
+        pkgs = import nixpkgs { inherit system; };
+
+        adb = pkgs.androidenv.androidPkgs_9_0.platform-tools;
+        jdk = pkgs.jdk;
+        nodejs = pkgs.nodejs;
+      in
+      {
+        devShell = pkgs.mkShell
+          {
+            buildInputs = [
+              adb
+              jdk
+              nodejs
+            ];
+            shellHook = ''
+              npm install
+            '';
+          };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds support for installing the deps with the NIx package manager. If you have NIx installed, all you have to do to use this tool is the following:

```bash
nix develop # This opens a new shell environment with the deps, without having to install them. This also automatically runs npm install.

node . --patch # Or whatever your patch command is
```