### PR TITLE
fix: use `os.EOL` for patchDescsArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,18 +32,20 @@ process.on('uncaughtException', async (err, origin) => {
 process.on('unhandledRejection', async (reason) => {
   console.log('An error occured.');
   console.log(reason);
-  console.log('\nPlease make an issue at https://github.com/reisxd/revanced-builder/issues.');
+  console.log(
+    '\nPlease make an issue at https://github.com/reisxd/revanced-builder/issues.'
+  );
   await exitProcess();
 });
 
-async function exitProcess () {
+async function exitProcess() {
   console.log('Press any key to exit...');
   process.stdin.setRawMode(true);
   process.stdin.resume();
   await new Promise(() => process.stdin.on('data', () => process.exit()));
 }
 
-async function overWriteJarNames (link) {
+async function overWriteJarNames(link) {
   const fileName = link.split('/').pop();
   // i have to use ifs for this sorry
   if (fileName.includes('revanced-cli')) jarNames.cli += fileName;
@@ -54,7 +56,7 @@ async function overWriteJarNames (link) {
   if (fileName.startsWith('microg')) jarNames.microG += fileName;
 }
 
-async function getDownloadLink (json) {
+async function getDownloadLink(json) {
   const apiRequest = await fetchURL(
     `https://api.github.com/repos/${json.owner}/${json.repo}/releases/latest`
   );
@@ -86,7 +88,7 @@ async function getDownloadLink (json) {
   return assets;
 }
 
-async function getPage (pageUrl) {
+async function getPage(pageUrl) {
   const pageRequest = await fetchURL(pageUrl, {
     headers: {
       'user-agent':
@@ -96,7 +98,7 @@ async function getPage (pageUrl) {
   return await pageRequest.text();
 }
 
-async function dloadFromURL (url, outputPath) {
+async function dloadFromURL(url, outputPath) {
   const request = await fetchURL(url, {
     headers: {
       'user-agent':
@@ -142,7 +144,7 @@ async function dloadFromURL (url, outputPath) {
   });
 }
 
-async function downloadYTApk (ytVersion) {
+async function downloadYTApk(ytVersion) {
   const versionsList = await getPage(
     'https://www.apkmirror.com/apk/google-inc/youtube'
   );
@@ -205,7 +207,7 @@ async function downloadYTApk (ytVersion) {
   return console.log('Download complete!');
 }
 
-async function downloadFile (assets) {
+async function downloadFile(assets) {
   for (const asset of assets) {
     const dir = fs.readdirSync('./revanced/');
     overWriteJarNames(asset.browser_download_url);
@@ -226,14 +228,14 @@ async function downloadFile (assets) {
   }
 }
 
-async function downloadFiles (repos) {
+async function downloadFiles(repos) {
   for (const repo of repos) {
     const downloadLink = await getDownloadLink(repo);
     await downloadFile(downloadLink);
   }
 }
 
-async function getADBDeviceID () {
+async function getADBDeviceID() {
   let deviceId;
   const { stdout } = await actualExec('adb devices');
   const match = stdout.match(/\r\n(.*?)\t/);
@@ -248,7 +250,7 @@ async function getADBDeviceID () {
   return deviceId;
 }
 
-async function checkForJavaADB () {
+async function checkForJavaADB() {
   try {
     const javaCheck = await actualExec('java -version');
     const javaVer = Array.from(javaCheck.stderr.matchAll(/version\s([^:]+)/g))
@@ -286,7 +288,7 @@ async function checkForJavaADB () {
   }
 }
 
-async function getYTVersion () {
+async function getYTVersion() {
   const { stdout, stderr } = await actualExec(
     'adb shell dumpsys package com.google.android.youtube'
   );
@@ -479,14 +481,15 @@ async function getYTVersion () {
 
       const patchesText = getPatches.stderr || getPatches.stdout;
       const firstWord = patchesText.slice(0, patchesText.indexOf(' '));
-      const regex = new RegExp(`${firstWord}\\s([^\\t]+)`, 'g');
+      const patchRegex = new RegExp(`${firstWord}\\s([^\\t]+)`, 'g');
 
       const patchesArray =
         getPatches.stdout.match(regex) || getPatches.stderr.match(regex);
 
+      const patchDescRegex = new RegExp(`\\t(.*) ${require('os').EOL}`, 'g');
       const patchDescsArray =
-        getPatches.stdout.match(/\t(.*) \r\n/g) ||
-        getPatches.stderr.match(/\t(.*) \r\n/g);
+        getPatches.stdout.match(patchDescRegex) ||
+        getPatches.stderr.match(patchDescRegex);
 
       const patchesChoice = [];
       let index = 0;


### PR DESCRIPTION
The `revanced-cli` apparently uses the line endings depending upon the platform:

- Windows: `\r\n`
- *Nix (Unix, Linux, MacOS, Android...): `\n`

This PR fixes the regex to rip the patch descriptions so that the EOL set by the platform is used, instead of hardcoding `\r\n`

fix #38 

Edit: Seems like Prettier did a LOT of changes, ignore them. The actual thing is from line 482~484