### PR TITLE
Explicitly include patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ If you want to exclude more, seperate the patches with a comma:
 $ node . --patch --exclude disable-shorts-button,microg-support
 ```
 
+If you want to explicitely include a patch, use the `--include` option, example:
+
+```bash
+$ node . --patch --include autorepeat-by-default
+```
+
+If you want to include more, seperate the patches with a comma (same as the exclude option).
+
 If you want to patch a specific YT version, download the APK, move it to this folder and rename it to `youtube.apk`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want to exclude more, seperate the patches with a comma:
 $ node . --patch --exclude disable-shorts-button,microg-support
 ```
 
-If you want to explicitely include a patch, use the `--include` option, example:
+If you want to explicitly include a patch, use the `--include` option, example:
 
 ```bash
 $ node . --patch --include autorepeat-by-default

--- a/index.js
+++ b/index.js
@@ -340,6 +340,7 @@ async function getYTVersion () {
 
     case 'patch': {
       let excludedPatches = '';
+      let includedPatches = '';
       let ytVersion;
       let isRooted = false;
 
@@ -399,9 +400,20 @@ async function getYTVersion () {
         }
         if (!argParser.options.exclude.includes(',')) {
           excludedPatches = ` -e ${argParser.options.exclude}`;
+        } else {
+          for (const patch of argParser.options.exclude.split(',')) {
+            excludedPatches += ` -e ${patch}`;
+          }
         }
-        for (const patch of argParser.options.exclude.split(',')) {
-          excludedPatches += ` -e ${patch}`;
+      }
+
+      if (argParser.options.include) {
+        if (!argParser.options.include.includes(',')) {
+          includedPatches = ` -i ${argParser.options.include}`;
+        } else {
+          for (const patch of argParser.options.include.split(',')) {
+            includedPatches += ` -i ${patch}`;
+          }
         }
       }
 
@@ -412,7 +424,7 @@ async function getYTVersion () {
       console.log('Building ReVanced, please be patient!');
 
       const { stdout, stderr } = await actualExec(
-        `java -jar ${jarNames.cli} -b ${jarNames.patchesJar} --experimental -a ./revanced/youtube.apk ${jarNames.deviceId} -o ./revanced/revanced.apk -m ${jarNames.integrations} ${excludedPatches}`,
+        `java -jar ${jarNames.cli} -b ${jarNames.patchesJar} --experimental -a ./revanced/youtube.apk ${jarNames.deviceId} -o ./revanced/revanced.apk -m ${jarNames.integrations} ${excludedPatches} ${includedPatches}`,
         { maxBuffer: 5120 * 1024 }
       );
       console.log(stdout || stderr);


### PR DESCRIPTION
Made it possible to include patches and fixed a small bug.

**Bug Fix**
When only excluding one patch, it would exclude the patch twice.
Example:
Input:
```bash
node . --patch --exclude disable-shorts-button
```
Produced ReVanced CLI command:
```bash
java -jar ${jarNames.cli} -b ${jarNames.patchesJar} --experimental -a ./revanced/youtube.apk ${jarNames.deviceId} -o ./revanced/revanced.apk -m ${jarNames.integrations} -e disable-shorts-button -e disable-shorts-button
```
How it should be:
```bash
java -jar ${jarNames.cli} -b ${jarNames.patchesJar} --experimental -a ./revanced/youtube.apk ${jarNames.deviceId} -o ./revanced/revanced.apk -m ${jarNames.integrations} -e disable-shorts-button
```

The double exclude doesn't really hurt but I fixed it anyway.