### PR TITLE
fix(temp): dirty workaround to a bug introduced by the CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -496,7 +496,7 @@ async function getYTVersion () {
       }
 
       const getPatches = await actualExec(
-        `java -jar ${jarNames.cli} -b ${jarNames.patchesJar} -l`
+        `java -jar ${jarNames.cli} -a ${jarNames.integrations} -b ${jarNames.patchesJar} -l`
       );
 
       const patchesText = getPatches.stderr || getPatches.stdout;


### PR DESCRIPTION
We're "tricking" the CLI to think we're giving it the
YouTube APK via `-a`, when all we are doing is simply passing it its own
integrations APK. This will be definitely reverted as soon as the CLI
fixes the weird issue.

Close #47