### PR TITLE
changed index.js so that compiled apks are only stored in "compiled" folder 

### DIFF
--- a/index.js
+++ b/index.js
@@ -813,6 +813,9 @@ async function mountReVanced(pkg) {
         await actualExec(
           'rm -r revanced-cache'
         );
+        await actualExec(
+          'rm -r compiled'
+        );
         console.log(
           'You now can install ReVanced and MicroG! Check /storage/emulated/0/'
         );

--- a/index.js
+++ b/index.js
@@ -384,6 +384,9 @@ async function preflight (listOnly) {
   if (fs.existsSync('./revanced-cache')) {
     fs.rmSync('./revanced-cache', { recursive: true, force: true });
   }
+  if (!fs.existsSync('./compiled')) {
+    fs.mkdirSync('./compiled');
+  }
   console.log('Downloading required files...');
 
   const filesToDownload = [
@@ -804,15 +807,32 @@ async function mountReVanced(pkg) {
         await actualExec(
           'cp revanced/microg.apk /storage/emulated/0/microg.apk'
         );
-
+        await actualExec(
+          'rm -r revanced'
+        );
+        await actualExec(
+          'rm -r revanced-cache'
+        );
         console.log(
           'You now can install ReVanced and MicroG! Check /storage/emulated/0/'
         );
-
+        
         await exitProcess();
       } else {
+        await actualExec(
+          'mv revanced/revanced.apk compiled/revanced.apk'
+        );
+        await actualExec(
+          'mv revanced/microg.apk compiled/microg.apk'
+        );
+        await actualExec(
+          'rm -r revanced'
+        );
+        await actualExec(
+          'rm -r revanced-cache'
+        );
         console.log(
-          'You now can install ReVanced and MicroG by transferring revanced/revanced.apk and revanced/microg.apk!'
+          'You now can install ReVanced and MicroG by transferring compiled/revanced.apk and compiled/microg.apk!'
         );
 
         await exitProcess();


### PR DESCRIPTION
changed index.js so that compiled apks are only stored in "compiled" folder for users who are not compiling from android phone also it's easy for users to transfer files to their phone from a folder with only compiled files. Also deletes cache files and other helper files so that files which are downloaded and stored in revanced folder are deleted. this code will not delete node_modules so that users don't have to download them repeatedly. 