### PR TITLE
fix: stderr log lines getting squished together

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -199,7 +199,7 @@ ws.onmessage = (msg) => {
         if (!alreadyAddedLog) {
           document.getElementsByClassName(
             'log'
-          )[0].innerHTML += `<strong>[builder]</strong> Downloading ${message.name}...<br/>`;
+          )[0].innerHTML += `<span class="log-line"><strong>[builder]</strong> Downloading ${message.name}...</span><br/>`;
           alreadyAddedLog = true;
         }
         document.getElementsByTagName('progress')[0].value =
@@ -208,7 +208,7 @@ ws.onmessage = (msg) => {
         currentFile = message.name;
         document.getElementsByClassName(
           'log'
-        )[0].innerHTML += `<strong>[builder]</strong> Downloading ${message.name}...<br/>`;
+        )[0].innerHTML += `<span class="log-line"><strong>[builder]</strong> Downloading ${message.name}...</span><br/>`;
         document.getElementsByTagName('progress')[0].value =
           '' + message.percentage / 100;
       }
@@ -219,7 +219,7 @@ ws.onmessage = (msg) => {
       hasFinished = true;
       document.getElementById('continue').classList.remove('disabled');
       document.getElementsByClassName('log')[0].innerHTML +=
-        '<strong>[builder]</strong> Finished downloading files<br>';
+        '<span class="log-line"><strong>[builder]</strong> Finished downloading files.</span><br/>';
       break;
     }
 
@@ -236,15 +236,9 @@ ws.onmessage = (msg) => {
     }
 
     case 'patchLog': {
-      if (message.isStdErr) {
-        document.getElementsByClassName(
-          'log'
-        )[0].innerHTML += `<div style="color: red;"><strong>[builder]</strong> ${message.log}<br></div>`;
-      } else {
-        document.getElementsByClassName(
-          'log'
-        )[0].innerHTML += `<strong>[builder]</strong> ${message.log}<br>`;
-      }
+      document.getElementsByClassName(
+        'log'
+      )[0].innerHTML += `<span class="log-line${message.isStdErr ? ' stderr' : ''}"><strong>[builder]</strong> ${message.log}</span><br>`;
       break;
     }
 

--- a/public/index.js
+++ b/public/index.js
@@ -8,11 +8,11 @@ let alreadyAddedLog = false;
 let isDownloading = false;
 let hasFinished = false;
 
-function sendCommand (args) {
+function sendCommand(args) {
   ws.send(JSON.stringify(args));
 }
 
-function setApp () {
+function setApp() {
   if (!document.querySelector('input[name="app"]:checked')) {
     return alert("You didn't select an app to patch!");
   }
@@ -23,27 +23,27 @@ function setApp () {
   location.href = '/dependencies';
 }
 
-function loadPatches () {
+function loadPatches() {
   sendCommand({ event: 'getPatches' });
 }
 
-function updateFiles () {
+function updateFiles() {
   sendCommand({ event: 'updateFiles' });
 }
 
-function toggle (bool) {
+function toggle(bool) {
   for (const checkbox of document.getElementsByClassName('select')) {
     checkbox.checked = bool;
   }
 }
 
-function goToPatches () {
+function goToPatches() {
   if (hasFinished) {
     location.href = '/patches';
   }
 }
 
-function setPatches () {
+function setPatches() {
   // To the person whos reading:
   // For some fucking reason, assigning the checked checkboxes into a constant variable would
   // give me an empty array. This is why I'm doing this -reis
@@ -85,7 +85,7 @@ function setPatches () {
   location.href = '/versions';
 }
 
-function setAppVersion () {
+function setAppVersion() {
   if (!isDownloading) {
     if (!document.querySelector('input[name="version"]:checked')) {
       return alert("You didn't select an app version!");
@@ -106,7 +106,7 @@ function setAppVersion () {
   }
 }
 
-function getAppVersions (isRooted) {
+function getAppVersions(isRooted) {
   document.getElementsByTagName('header')[0].innerHTML = `
     <h1>Select the version you want to download</h1>
     ${
@@ -124,22 +124,22 @@ function getAppVersions (isRooted) {
   sendCommand({ event: 'getAppVersion' });
 }
 
-function buildReVanced () {
+function buildReVanced() {
   sendCommand({ event: 'patchApp' });
 }
 
-function getAlreadyExists () {
+function getAlreadyExists() {
   sendCommand({ event: 'checkFileAlreadyExists' });
 }
-function openAbout () {
+function openAbout() {
   window.open('/about', '_blank');
 }
 
-function openGitHub () {
+function openGitHub() {
   window.open('https://github.com/reisxd/revanced-builder', '_blank');
 }
 
-function toTitleCase (phrase) {
+function toTitleCase(phrase) {
   return phrase
     .split('-')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -238,7 +238,9 @@ ws.onmessage = (msg) => {
     case 'patchLog': {
       document.getElementsByClassName(
         'log'
-      )[0].innerHTML += `<span class="log-line${message.isStdErr ? ' stderr' : ''}"><strong>[builder]</strong> ${message.log}</span><br>`;
+      )[0].innerHTML += `<span class="log-line${
+        message.isStdErr ? ' stderr' : ''
+      }"><strong>[builder]</strong> ${message.log}</span><br>`;
       break;
     }
 

--- a/public/styles/dependencies.css
+++ b/public/styles/dependencies.css
@@ -1,4 +1,4 @@
-span.log {
+span.log .log-line {
   font-family: 'Fira Code', monospace;
   font-weight: 300;
   font-size: 0.8em;
@@ -6,6 +6,11 @@ span.log {
   width: 100%;
   height: 100%;
 }
+
+span.log .log-line.stderr {
+  color: #d21404;
+}
+
 span.log:after {
   content: '｜';
   animation: blinking-cursor 1s steps(2, start) infinite;


### PR DESCRIPTION
Styles for span.log didn't apply when logs from stderr were wrapped inside a `<div style="color: red;">`. This made the log distorted.

This change would make it so that *every* log line would be wrapped with `span.log-line`, and the base styles are applied for this. If the logs are from stderr, an extra class `.stderr` would be added.