### PR TITLE
fix mount command so it doesn't require restart

### DIFF
--- a/utils/mountReVanced.js
+++ b/utils/mountReVanced.js
@@ -45,6 +45,12 @@ module.exports = async function (pkg, ws) {
   // Kill mounted process
   // await actualExec(`su -c 'monkey -p ${pkg} 1 && kill $(pidof -s ${pkg})'`);
 
+  // Mount APK with command so it doesn't require restart
+  await actualExec(`su -mm -c 'base_path="/data/adb/revanced/${pkg}.apk";stock_path=$( pm path ${pkg} | grep base | sed 's/package://g' );mount -o bind $base_path $stock_path'`)
+  // Kill app process 
+  await actualExec(`su -c 'am force-stop ${pkg}'`);
+
+
   ws.send(
     JSON.stringify({
       event: 'patchLog',


### PR DESCRIPTION
Refer to
https://github.com/TeamVanced/VancedManager/blob/compose/app/src/main/java/com/vanced/manager/installer/util/Patcher.kt#L88
About "-mm" option for su 
https://github.com/topjohnwu/Magisk/blob/master/docs/tools.md#su
```
-mm, -M,
  --mount-master                force run in the global mount namespace
```