### PR TITLE
fix: `-all` is removed in CLI file names

### DIFF
--- a/wsEvents/PatchApp.js
+++ b/wsEvents/PatchApp.js
@@ -184,7 +184,7 @@ function outputName () {
     global.jarNames.cli
       .split('/')[2]
       .replace('revanced-cli-', '')
-      .replace('-all.jar', '');
+      .replace('.jar', '');
   const part6 =
     'patches_' +
     global.jarNames.patchesJar


### PR DESCRIPTION
Signed-off-by: shrihanDev <shrihankp198725@gmail.com>
