### PR TITLE
fix: Update patches anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ReVanced Builder
 
-This project will allow you to download the APK of any of the [officially supported](https://github.com/revanced/revanced-patches#-list-of-available-patches) apps and build ReVanced easily!
+This project will allow you to download the APK of any of the [officially supported](https://github.com/revanced/revanced-patches#-patches) apps and build ReVanced easily!
 
 ## Required
 


### PR DESCRIPTION
As of commit 04a0f9c3e0b1ae868782afa752ea7c6fac88359c, the anchor link for the list of patches has changed. This commit ensures users are sent to the correct spot on the page automatically.