### PR TITLE
Revert "downloadingFile" logging part

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -287,7 +287,12 @@ ws.onmessage = (msg) => {
 
         const downloadMessage = `<span class="log-line"><strong>[builder]</strong> Downloading ${message.name}...</span><br/>`;
 
-        if (currentFile !== message.name) {
+        if (currentFile === message.name) {
+          if (!alreadyAddedLog) {
+            logElement.innerHTML += downloadMessage;
+            alreadyAddedLog = true;
+          }
+        } else {
           currentFile = message.name;
           logElement.innerHTML += downloadMessage;
         }


### PR DESCRIPTION
The old code was actually better, because the new one doesn't take in consideration when the currentFile is equal to message.name from the start - that's why the "Downloading youtube.apk..." was not shown.
Reverting this fixes the issue.

You are smart, just trust yourself more 🙃😂

EDIT: AWW SH*T THE DOUBLE LOG 😩