### PR TITLE
feat[ci]: (alpha) add workflow for building bootstraps

### DIFF
--- a/.github/workflows/build-rvba-bootstraps.yml
+++ b/.github/workflows/build-rvba-bootstraps.yml
@@ -1,0 +1,44 @@
+name: "[Alpha] Build RVBA Bootstraps"
+
+on: workflow_dispatch
+
+jobs:
+  build-bootstraps:
+    strategy:
+      matrix:
+        arch: [aarch64, arm]
+    steps:
+      - name: Clone termux-packages
+        uses: actions/checkout@v3
+        with:
+          repository: 'termux/termux-packages'
+      - name: Patch generate script
+        run: |
+          PKGS_TO_REMOVE='bzip2 proot diffutils findutils gawk grep less procps psmisc sed tar termux-keyring nano util-linux xz-utils ed debianutils dos2unix inetutils lsof net-tools patch'
+          for pkg in $PKGS_TO_REMOVE; do
+            sed -i "s@pull_package $pkg@echo \"$pkg, take a huge L\"@g" ./scripts/generate-bootstraps.sh
+          done
+      - name: Build bootstrap for ${{ matrix.arch }}
+        run: |
+          ./scripts/run-docker.sh ./scripts/generate-bootstraps.sh --architectures ${{ matrix.arch }} --add nodejs-lts,openjdk-17 --android10
+      - name: Shrinking bootstrap as much as possible
+        run: |
+          ZIP=$(find -type f -name 'bootstrap-${{ matrix.arch }}.zip')
+          mkdir tmp && cd tmp
+          unzip $ZIP
+          RM_PATHS="etc/cups etc/fonts include share/man share/doc share/bash-completion share/examples share/fonts share/fontconfig share/cups share/X11 opt/openjdk/legal opt/openjdk/demo opt/openjdk/man"
+          rm -rf "$RM_PATHS"
+          zip -r bootstrap-${{ matrix.arch }}-shrunk.zip *
+          mv bootstrap-${{ matrix.arch }}-shrunk.zip $(dirname $ZIP)
+          cd ..
+          rm -rf tmp
+      - name: Upload bootstrap-${{ matrix.arch }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-${{ matrix.arch }}
+          path: termux-packages/**/bootstrap-${{ matrix.arch }}.zip
+      - name: Upload bootstrap-${{ matrix.arch }}-shrunk
+        uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-${{ matrix.arch }}-shrunk
+          path: termux-packages/**/bootstrap-${{ matrix.arch }}-shrunk.zip


### PR DESCRIPTION
Take the first step towards it, I guess :P

Some considerations, because its too _alpha_:

1. This workflow runs only when asked. This'll change to every tag push once things reach stability.
2. This workflow builds four bootstraps: two for each of `aarch64` and `arm`. One is the output of the generate script directly, and other is a modified one except some things are deleted. This'll change once its fully confirmed that the modified builds work.
3. This workflow does NOT add the login scripts. Thats a TODO for now.
4. This workflow does NOT build the app itself. That is also a sort of TODO in reisxd/termux-app.
5. This workflow uploads stuff to artifacts. This'll change later to upload to Releases.
