### PR TITLE
Make error logs user selectable

### DIFF
--- a/public/styles/failure.css
+++ b/public/styles/failure.css
@@ -6,6 +6,7 @@ span.log-error {
   line-height: 0.8em;
   width: 100%;
   height: 100%;
+  user-select: text;
 }
 span.log:after {
   content: '｜';


### PR DESCRIPTION
Making error logs selectable will make it easier to copy logs or links.