### PR TITLE
allow text selection in search bar

### DIFF
--- a/public/styles/patches.css
+++ b/public/styles/patches.css
@@ -53,4 +53,5 @@ li {
   border: 2px solid #dddddd2e;
   font-size: 14px;
   margin-top: 5px;
+  user-select: auto;
 }


### PR DESCRIPTION
Chrome allows it by default for input box but idk why firefox doesn't so this fix only targets firefox users.
Firefox applies [this](https://github.com/reisxd/revanced-builder/blob/209a96178a68facbb721d8cc8b0ea54a7a1e4273/public/styles/core.css#L33) to input box too LOL