### PR TITLE
Added quotes for paths with spaces

### DIFF
--- a/wsEvents/installReVanced.js
+++ b/wsEvents/installReVanced.js
@@ -17,10 +17,10 @@ module.exports = async function installReVanced(ws) {
       );
       try {
         await exec(
-          `adb -s ${deviceId} install ${joinPath(
+          `adb -s ${deviceId} install "${joinPath(
             global.revancedDir,
             global.outputName
-          )}`
+          )}"`
         );
 
         ws.send(
@@ -92,7 +92,7 @@ module.exports = async function installReVanced(ws) {
 
       if (!microGVersion || microGVersion !== currentMicroGVersion) {
         try {
-          await exec(`adb -s ${deviceId} install ${global.jarNames.microG}`);
+          await exec(`adb -s ${deviceId} install "${global.jarNames.microG}"`);
 
           ws.send(
             JSON.stringify({


### PR DESCRIPTION
When trying to install the APKs with a space in their folder paths, the command fails as the space separates the folder paths.
Quotes tells the command that the space is part of the folder path (Everything in the quotes is a single path!)
```
Error: Command failed: adb -s (DEVICEIDforPrivacy) install C:\Users\Windows Games\Downloads\revanced\ReVanced-YouTube-v17.36.37-cli_v2.13.0-patches_v2.77.1.apk
adb: failed to stat Games\Downloads\revanced\ReVanced-YouTube-v17.36.37-cli_v2.13.0-patches_v2.77.1.apk: No such file or directory
```