### PR TITLE
Fixed a black theme bug

### DIFF
--- a/public/styles/patches.css
+++ b/public/styles/patches.css
@@ -1,6 +1,9 @@
 html.black
   input[type='checkbox'].select
-  + label:not(input[type='checkbox'].select:checked + label),
++ label:not(input[type='checkbox'].select:checked + label) {
+  background-color: black !important;
+}
+
 input[type='checkbox'] {
   display: none;
 }


### PR DESCRIPTION
While shifting css styles from patches.css to core.css you mistakenly introduced this bug: https://github.com/reisxd/revanced-builder/commit/a7c0524d53092f258e0aebb6ea6c0b6593e1f980