### PR TITLE
Remove the wakelock request

### DIFF
--- a/android-interface.sh
+++ b/android-interface.sh
@@ -112,7 +112,6 @@ Possible reasons (in the order of commonality):
     log "revanced-builder found."
     log "All checks done."
   fi
-  termux-wake-lock
 }
 
 run_builder() {


### PR DESCRIPTION
When running Termux, it already has a permanent notification which prevents it from being killed as much as possible. Asking for a wakelock would be useful against doze mode, which usually kicks in after 30ish minutes after the screen got locked. So to my knowledge it is not necessary for this usage.
Or if you think it is necessary I will open a new PR, because the wakelock is still not released automatically after running the builder.