### PR TITLE
Add page selection for app version

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -162,7 +162,7 @@ function setAppVersion(arch, version) {
 /**
  * @param {boolean} isRooted
  */
-function getAppVersions(isRooted) {
+function getAppVersions(isRooted, page = 1) {
   document.getElementsByTagName('header')[0].innerHTML = `
     <h1><i class="fa-solid fa-file-arrow-down"></i>Select the version you want to download</h1>
     <span>Versions marked as beta might have bugs or can be unstable, unless marked as recommended<span>
@@ -181,7 +181,9 @@ function getAppVersions(isRooted) {
   backButton.innerHTML = 'Back';
   backButton.onclick = () => history.back();
 
-  sendCommand({ event: 'getAppVersion', checkVer: true });
+  if (page < 1) page = 1;
+
+  sendCommand({ event: 'getAppVersion', checkVer: true, page });
 }
 
 function buildReVanced() {
@@ -370,6 +372,13 @@ ws.onmessage = (msg) => {
         const len = message.versionList.length;
 
         const versionsElement = document.getElementById('versions');
+        versionsElement.innerHTML = '';
+
+        versionsElement.innerHTML += `
+          <li>
+          ${message.page != 1 ? `<button id="prevPage" onclick="getAppVersions(${message.isRooted}, ${message.page - 1})">Previous Page</button>` : ""}
+          <button id="nextPage" onclick="getAppVersions(${message.isRooted}, ${message.page + 1})">Next Page</button>
+        </li>`;
 
         for (let i = 0; i < len; i++) {
           const version = message.versionList[i];

--- a/wsEvents/getAppVersion.js
+++ b/wsEvents/getAppVersion.js
@@ -9,7 +9,7 @@ const { getAppVersion: getAppVersion_ } = require('../utils/getAppVersion.js');
 const { downloadApp: downloadApp_ } = require('../utils/downloadApp.js');
 const getDeviceArch = require('../utils/getDeviceArch.js');
 
-const APKMIRROR_UPLOAD_BASE = 'https://www.apkmirror.com/uploads/?appcategory=';
+const APKMIRROR_UPLOAD_BASE = (page) => `https://www.apkmirror.com/uploads/page/${page}/?appcategory=`;
 
 /**
  * @param {string} ver
@@ -124,7 +124,7 @@ async function downloadApp(ws, message) {
  */
 module.exports = async function getAppVersion(ws, message) {
   let versionsList = await getPage(
-    `${APKMIRROR_UPLOAD_BASE}${global.jarNames.selectedApp.link.split('/')[3]}`
+    `${APKMIRROR_UPLOAD_BASE(message.page || 1)}${global.jarNames.selectedApp.link.split('/')[3]}`
   );
 
   if (global.jarNames.isRooted) {
@@ -229,11 +229,13 @@ module.exports = async function getAppVersion(ws, message) {
     JSON.stringify({
       event: 'appVersions',
       versionList,
+      page: message.page || 1,
       selectedApp: global.jarNames.selectedApp.packageName,
       foundDevice:
         global.jarNames.devices && global.jarNames.devices[0]
           ? true
-          : process.platform === 'android'
+          : process.platform === 'android',
+      isRooted: global.jarNames.isRooted
     })
   );
 };


### PR DESCRIPTION
* Add page switcher for version selection (specifically YouTube) because the recommended version would not appear on the first page of results

Addresses issues #666, #667, #674, #676, #680, #681, and probably more that I'm too lazy to find

Download binaries: https://github.com/imaperson1060/revanced-builder/releases/tag/v3.9.0-pages

Detailed explanation:
* Currently, the version list is pulled from the first page of recent releases for the YouTube app on ApkMirror.
* Since the patches haven't been updated for a while, the recommended version is no longer on the first page of results.
* This PR adds "Next" and "Previous" buttons for page navigation, which allows the recommended version to be selected within Revanced Builder