### PR TITLE
Update regex inside sanitizeVersion

### DIFF
--- a/wsEvents/getAppVersion.js
+++ b/wsEvents/getAppVersion.js
@@ -19,7 +19,7 @@ const sanitizeVersion = (ver) => {
   while (ver.match(/\./g).length > 2) ver = ver.replace(/.([^.]*)$/, '$1');
 
   return ver
-    .replace(/\.0(\d)/gi, '.$1') // because apparently x.0y.z (ex. 5.09.51) isn't a valid version
+    .replace(/\.0(\d+)/gi, '.$1') // because apparently x.0y.z (ex. 5.09.51) isn't a valid version
     .replace(/^(\d+)\.(\d+)$/gi, '$1.$2.0'); // nor are versions without a patch (ex. 2.3)
 };
 


### PR DESCRIPTION
Enables sanitizing multi-digit numbers with a leading zero.

Fixes #648 